### PR TITLE
Fix scrolling cursor into view

### DIFF
--- a/assets/ace.js
+++ b/assets/ace.js
@@ -13,6 +13,7 @@ require(["gitbook", "jquery"], function(gitbook, $) {
             var editor = ace.edit(id);
             editor.setTheme('ace/theme/chrome');
             editor.setOptions({
+                autoScrollEditorIntoView: true,
                 maxLines: 100
             });
 


### PR DESCRIPTION
This enables scrolling cursor into view when editor container itself is partially scrolled out of view